### PR TITLE
msm: kgsl: Prevent GPU boost when battery saver is on

### DIFF
--- a/drivers/gpu/msm/kgsl_pwrctrl.c
+++ b/drivers/gpu/msm/kgsl_pwrctrl.c
@@ -22,6 +22,7 @@
 #include <linux/msm_adreno_devfreq.h>
 #include <linux/of_device.h>
 #include <linux/thermal.h>
+#include <linux/battery_saver.h>
 
 #include "kgsl.h"
 #include "kgsl_pwrscale.h"
@@ -644,6 +645,9 @@ static void kgsl_pwrctrl_min_pwrlevel_set(struct kgsl_device *device,
 	/* You can't set a minimum power level lower than the maximum */
 	if (level < pwr->max_pwrlevel)
 		level = pwr->max_pwrlevel;
+
+	if (is_battery_saver_on())
+		level = pwr->num_pwrlevels - 2;
 
 	pwr->min_pwrlevel = level;
 


### PR DESCRIPTION
 * we force gpu to run at max freq during expensive
   rendering in order to mitigate jank during blur,
   but no need to do this in battery saver mode

Signed-off-by: K A R T H I K <karthik.lal558@gmail.com>
Signed-off-by: arnavpuranik <puranikarnav@gmail.com>